### PR TITLE
Add automatic WebSocket reconnection with exponential backoff

### DIFF
--- a/frontend/src/views/Controller.vue
+++ b/frontend/src/views/Controller.vue
@@ -453,6 +453,11 @@ Happy teleprompting! 🎬`,
 
       // Connection tracking
       lastConnectionCount: 0,
+
+      // Auto-reconnect state
+      reconnectDelay: 1000,
+      reconnectTimer: null,
+      isUnmounting: false,
     };
   },
 
@@ -517,6 +522,8 @@ Happy teleprompting! 🎬`,
   },
 
   beforeUnmount() {
+    this.isUnmounting = true;
+    clearTimeout(this.reconnectTimer);
     if (this.ws) {
       this.ws.close();
     }
@@ -526,7 +533,6 @@ Happy teleprompting! 🎬`,
     async initializeRoom() {
       try {
         await this.connectWebSocket();
-        this.showSnackbar("Connected to teleprompter server", "success");
       } catch (error) {
         console.error("Failed to initialize connection:", error);
         this.showSnackbar("Failed to connect to server", "error");
@@ -613,7 +619,9 @@ Happy teleprompting! 🎬`,
       this.ws = new WebSocket(wsFullUrl);
 
       this.ws.onopen = () => {
+        this.reconnectDelay = 1000;
         console.log("WebSocket connected");
+        this.showSnackbar("Connected to teleprompter server", "success");
       };
 
       this.ws.onmessage = (event) => {
@@ -627,13 +635,23 @@ Happy teleprompting! 🎬`,
 
       this.ws.onerror = (error) => {
         console.error("WebSocket error:", error);
-        this.showSnackbar("Connection error", "error");
+        // onerror is always followed by onclose — let onclose drive reconnect
       };
 
       this.ws.onclose = () => {
         console.log("WebSocket disconnected");
-        this.showSnackbar("Disconnected from server", "warning");
+        if (this.isUnmounting) return;
+        this.showSnackbar("Disconnected — reconnecting...", "warning");
+        this.scheduleReconnect();
       };
+    },
+
+    scheduleReconnect() {
+      this.reconnectTimer = setTimeout(() => {
+        if (this.isUnmounting) return;
+        this.connectWebSocket();
+      }, this.reconnectDelay);
+      this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000);
     },
 
     handleWebSocketMessage(message) {

--- a/frontend/src/views/Teleprompter.vue
+++ b/frontend/src/views/Teleprompter.vue
@@ -85,6 +85,9 @@ export default {
         text: "",
         color: "success",
       },
+      reconnectDelay: 1000,
+      reconnectTimer: null,
+      isUnmounting: false,
     };
   },
 
@@ -139,6 +142,8 @@ export default {
   },
 
   beforeUnmount() {
+    this.isUnmounting = true;
+    clearTimeout(this.reconnectTimer);
     if (this.ws) {
       this.ws.close();
     }
@@ -180,6 +185,7 @@ export default {
 
     setupWebSocketHandlers() {
       this.ws.onopen = () => {
+        this.reconnectDelay = 1000;
         console.log("WebSocket connected");
         this.showSnackbar("Connected to teleprompter channel", "success");
       };
@@ -195,13 +201,23 @@ export default {
 
       this.ws.onerror = (error) => {
         console.error("WebSocket error:", error);
-        this.showSnackbar("Connection error", "error");
+        // onerror is always followed by onclose — let onclose drive reconnect
       };
 
       this.ws.onclose = () => {
         console.log("WebSocket disconnected");
-        this.showSnackbar("Disconnected from server", "warning");
+        if (this.isUnmounting) return;
+        this.showSnackbar("Disconnected — reconnecting...", "warning");
+        this.scheduleReconnect();
       };
+    },
+
+    scheduleReconnect() {
+      this.reconnectTimer = setTimeout(() => {
+        if (this.isUnmounting) return;
+        this.connect();
+      }, this.reconnectDelay);
+      this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000);
     },
 
     handleMessage(message) {


### PR DESCRIPTION
## Summary
Implements automatic reconnection logic for WebSocket connections in both the Controller and Teleprompter components, with exponential backoff to gracefully handle temporary network disruptions.

## Key Changes
- **Auto-reconnect mechanism**: Added `scheduleReconnect()` method to both components that automatically attempts to reconnect after a WebSocket disconnection
- **Exponential backoff**: Reconnection delay starts at 1 second and doubles with each attempt, capped at 30 seconds, resetting to 1 second on successful connection
- **Graceful unmounting**: Added `isUnmounting` flag to prevent reconnection attempts during component cleanup
- **Improved error handling**: 
  - Removed redundant error snackbar from `onerror` handler (since `onclose` always follows)
  - Updated disconnect message to indicate reconnection is in progress
  - Moved success snackbar from `initializeRoom()` to `onopen` handler for more accurate timing
- **Connection state tracking**: Added `reconnectDelay`, `reconnectTimer`, and `isUnmounting` to component data

## Implementation Details
- The `beforeUnmount()` hook now sets `isUnmounting = true` and clears any pending reconnect timers to prevent reconnection attempts after component destruction
- The `onclose` handler checks `isUnmounting` before scheduling a reconnect
- The `scheduleReconnect()` method also checks `isUnmounting` before attempting to reconnect, providing a safety net against race conditions
- Changes applied consistently to both Controller.vue and Teleprompter.vue components

https://claude.ai/code/session_01MgQytiqf9k9XbpNf4PpEhJ